### PR TITLE
Fix data types for Node and ExportSetting structs

### DIFF
--- a/node.go
+++ b/node.go
@@ -116,7 +116,7 @@ type Node struct {
 	IsMask              bool
 	Fills               []Paint     `json:"fills,omitempty"`
 	Strokes             []Paint     `json:"strokes,omitempty"`
-	StrokeWeight        int         `json:"strokeWeight,omitempty"`
+	StrokeWeight        float64     `json:"strokeWeight,omitempty"`
 	StrokeAlign         StrokeAlign `json:"strokeAlign,omitempty"`
 	Characters          string      `json:"characters,omitempty"`
 	Style               TypeStyle   `json:"style,omitempty"`

--- a/types.go
+++ b/types.go
@@ -193,7 +193,7 @@ type Rectangle struct {
 type ExportSetting struct {
 	Suffix     string
 	Format     ImageFormat
-	Constraint string
+	Constraint Constraint
 }
 
 // Constraint describes sizing constraint for exports.


### PR DESCRIPTION
### Description
Found errors caused by type discrepancies while trying to `json.Marshal` a figma `File`.
Made type changes for StrokeWeight and Constraint to Node and ExportSetting structs repectively.

### Tests
Only ran a few local tests, with private tokens.
No new tests were added.

### Changes Made
**Node**
- StrokeWeight: changed from `int` to `float64`

**ExportSetting**
- Constraint: changed from `string` to `Constraint`